### PR TITLE
Id image upload for booking confirmation

### DIFF
--- a/scp/android/app/build.gradle
+++ b/scp/android/app/build.gradle
@@ -44,7 +44,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "in.ac.nitrkl.scp.scp"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/scp/lib/booking.dart
+++ b/scp/lib/booking.dart
@@ -37,8 +37,8 @@ class _BookingState extends State<Booking> {
     hasBooked = prefs.getBool('hasBooked');
     bookedDate = prefs.getString('bookedDate');
     bookedTime = prefs.getString('bookedTime');
-    //return prefs.getString('type');
 
+    //return prefs.getString('type');
   }
 
   Future<RemoteConfig> _setupRemoteConfig() async {

--- a/scp/lib/camera.dart
+++ b/scp/lib/camera.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:camera/camera.dart';
+import 'package:flutter/material.dart';
+
+void uploadImage(BuildContext context, String path, Function setValid) async {
+  final cameras = await availableCameras();
+  final firstCamera = cameras.first;
+
+  print('Ankesh $path');
+
+  Navigator.push(
+      context,
+      MaterialPageRoute(
+          builder: (context) => TakePictureScreen(
+                camera: firstCamera,
+                storePath: path,
+                setValidImage: setValid,
+              )));
+
+  print('Ankesh $path');
+}
+
+// A screen that allows users to take a picture using a given camera.
+class TakePictureScreen extends StatefulWidget {
+  final CameraDescription camera;
+  final storePath;
+  final setValidImage;
+
+  const TakePictureScreen(
+      {Key key,
+      @required this.camera,
+      @required this.storePath,
+      this.setValidImage})
+      : super(key: key);
+
+  @override
+  TakePictureScreenState createState() =>
+      TakePictureScreenState(path: storePath);
+}
+
+class TakePictureScreenState extends State<TakePictureScreen> {
+  final String path;
+
+  CameraController _controller;
+  Future<void> _initializeControllerFuture;
+  double queryWidth;
+
+  TakePictureScreenState({this.path});
+
+  @override
+  void initState() {
+    super.initState();
+    // To display the current output from the Camera,
+    // create a CameraController.
+    _controller = CameraController(
+      // Get a specific camera from the list of available cameras.
+      widget.camera,
+      // Define the resolution to use.
+      ResolutionPreset.medium,
+    );
+
+    // Next, initialize the controller. This returns a Future.
+    _initializeControllerFuture = _controller.initialize();
+  }
+
+  @override
+  void dispose() {
+    // Dispose of the controller when the widget is disposed.
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    queryWidth = MediaQuery.of(context).size.width;
+    return Scaffold(
+      // Wait until the controller is initialized before displaying the
+      // camera preview. Use a FutureBuilder to display a loading spinner
+      // until the controller has finished initializing.
+      body: Stack(children: [
+        FutureBuilder<void>(
+          future: _initializeControllerFuture,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.done) {
+              // If the Future is complete, display the preview.
+              return CameraPreview(_controller);
+            } else {
+              // Otherwise, display a loading indicator.
+              return Center(child: CircularProgressIndicator());
+            }
+          },
+        ),
+        Align(
+          alignment: Alignment.topCenter,
+          child: Container(
+            height: MediaQuery.of(context).size.height * 0.3,
+            width: MediaQuery.of(context).size.width,
+            color: Colors.black.withOpacity(0.2),
+          ),
+        ),
+        Align(
+          alignment: Alignment.bottomCenter,
+          child: Container(
+            height: MediaQuery.of(context).size.height * 0.3,
+            width: MediaQuery.of(context).size.width,
+            color: Colors.black.withOpacity(0.2),
+          ),
+        ),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: Container(
+            height: MediaQuery.of(context).size.height * 0.4,
+            width: MediaQuery.of(context).size.width * 0.05,
+            color: Colors.black.withOpacity(0.2),
+          ),
+        ),
+        Align(
+          alignment: Alignment.centerRight,
+          child: Container(
+            height: MediaQuery.of(context).size.height * 0.4,
+            width: MediaQuery.of(context).size.width * 0.05,
+            color: Colors.black.withOpacity(0.2),
+          ),
+        ),
+        Align(
+          alignment: Alignment.center,
+          child: Container(
+            height: MediaQuery.of(context).size.height * 0.4,
+            width: MediaQuery.of(context).size.width * 0.9,
+            decoration: BoxDecoration(
+              border: Border.all(width: 2.0, color: Color.fromRGBO(25, 39, 45, 1)),
+            ),
+          ),
+        ),
+        Align(
+          alignment: Alignment.bottomCenter,
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: FloatingActionButton(
+              child: Icon(
+                Icons.camera_alt,
+                color: Colors.white,
+              ),
+              backgroundColor: Color.fromRGBO(25, 39, 45, 1),
+              // Provide an onPressed callback.
+              onPressed: () async {
+                // Take the Picture in a try / catch block. If anything goes wrong,
+                // catch the error.
+                try {
+                  // Ensure that the camera is initialized.
+                  await _initializeControllerFuture;
+
+                  // Attempt to take a picture and log where it's been saved.
+                  await _controller.takePicture(widget.storePath);
+
+                  print(widget.storePath);
+
+                  // If the image was taken then set validImage and exit camera screen.
+                  widget.setValidImage();
+                  Navigator.pop(context);
+                } catch (e) {
+                  // If an error occurs, log the error to the console.
+                  print(e);
+                }
+              },
+            ),
+          ),
+        ),
+      ]),
+    );
+  }
+}

--- a/scp/lib/main.dart
+++ b/scp/lib/main.dart
@@ -21,6 +21,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'timetable/theorySection.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'timetablecardsplit.dart';
 
 var firebaseInstance = FirebaseAuth.instance;
 final privacyPolicy = "https://project-avocado-8b3e1.firebaseapp.com";

--- a/scp/lib/ui/cards.dart
+++ b/scp/lib/ui/cards.dart
@@ -8,6 +8,7 @@ import 'package:scp/firebase/firebaseDBHandler.dart';
 import 'package:scp/utils/sizeConfig.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../utils/models.dart';
+import 'package:scp/upload_image.dart';
 
 const platform = const MethodChannel("FAQ_ACTIVITY");
 Widget appointmentCard(BuildContext context) {
@@ -19,7 +20,7 @@ Widget appointmentCard(BuildContext context) {
     child: Padding(
       padding: const EdgeInsets.only(top: 12.0),
       child: InkWell(
-        onTap: () async {
+      onTap:() async {
           SharedPreferences prefs = await SharedPreferences.getInstance();
           if (prefs.getBool('hasBooked') == true) {
             Navigator.of(context).push(MaterialPageRoute(
@@ -479,8 +480,6 @@ var gKey, gCounselDay, gTime;
 
 Widget slotCard(
     BuildContext context,
-    //double heightFactor,
-    //double textScaleFactor,
     String counselDay,
     String date,
     String titleText,
@@ -496,42 +495,6 @@ Widget slotCard(
     SizeConfig().init(context);
     double heightFactor = SizeConfig.screenWidth;
 
-    void bookAppointment(String key) async {
-      print(counselDay);
-      SharedPreferences prefs = await SharedPreferences.getInstance();
-      var rollNo = prefs.getString('roll_no');
-      var phoneNo = prefs.getString('phone_no');
-      //prefs.setString('counselPsychDay', counselDay);
-      prefs.setBool('hasBooked', true);
-      prefs.setString('bookedDate', date);
-      prefs.setString('bookingType', type);
-      prefs.setString(
-          'bookDate',
-          ((type == "psych")
-              ? DateConfig.psychDate.toString()
-              : DateConfig.counselDate.toString()));
-      print(DateConfig.bookedDate.toString());
-      gCounselDay = counselDay;
-      gKey = key;
-      gTime = time;
-      prefs.setString('bookedTime', gTime);
-
-      var reference =
-          (type == "psych") ? ScpDatabase.psychRef : ScpDatabase.counselRef;
-
-      await reference.child(key).update({
-        "phoneNo": phoneNo,
-        "rollNo": rollNo,
-        "status": "1",
-      }).then((_) {
-        print("Value updated");
-        Navigator.of(context).pop();
-        Navigator.of(context).push(MaterialPageRoute(
-            builder: (BuildContext context) =>
-                Booking(keyCode: key, counselDay: counselDay, time: time)));
-      });
-    }
-
     return StatefulBuilder(
       builder: (BuildContext context, StateSetter setSlotWidgetState) {
         return InkWell(
@@ -542,43 +505,13 @@ Widget slotCard(
                   isSelected = !isSelected;
                 });
 
-                showDialog(
-                  context: context,
-                  builder: (BuildContext context) {
-                    return AlertDialog(
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(10.0),
-                      ),
-                      title: Text('Confirm Slot Booking?'),
-                      actions: <Widget>[
-                        FlatButton(
-                          onPressed: () {
-                            setSlotWidgetState(() {
-                              isSelected = !isSelected;
-                            });
-                            Navigator.pop(context);
-                          },
-                          child: Text('CANCEL'),
-                          textColor: Colors.cyan,
-                        ),
-                        RaisedButton(
-                          color: Colors.cyan,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(8.0),
-                          ),
-                          onPressed: () {
-                            //SharedPreferences prefs = await SharedPreferences.getInstance();
-                            //prefs.setBool("isBookingActive", true);
-                            Navigator.pop(context);
-                            bookAppointment(key);
-                          },
-                          child: Text('BOOK'),
-                          textColor: Colors.white,
-                        ),
-                      ],
-                    );
-                  },
-                );
+                Navigator.push(context, MaterialPageRoute(builder: (context) => UploadImageScreen(
+                  bookingKey: key,
+                  time: time,
+                  counselDay: counselDay,
+                  date: date,
+                  type: type,
+                )));
                 break;
               case "1":
                 Scaffold.of(context).showSnackBar(
@@ -714,4 +647,5 @@ Widget slotCard(
       ),
     ),
   );
+
 }

--- a/scp/lib/upload_image.dart
+++ b/scp/lib/upload_image.dart
@@ -1,0 +1,262 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:scp/camera.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart';
+import 'package:scp/utils/sizeConfig.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:scp/dateConfig.dart';
+import 'package:scp/firebase/firebaseDBHandler.dart';
+import 'package:scp/booking.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+
+class UploadImageScreen extends StatefulWidget {
+  final String counselDay;
+  final String date;
+  final String type;
+  final String time;
+  final String bookingKey;
+
+  UploadImageScreen(
+      {this.bookingKey, this.time, this.type, this.date, this.counselDay});
+
+  @override
+  UploadImageState createState() => UploadImageState();
+}
+
+class UploadImageState extends State<UploadImageScreen> {
+  GlobalKey<ScaffoldState> _scafoldKey = new GlobalKey();
+  double queryWidth;
+  String imagePath = "";
+  bool validImage = false;
+  bool uploading = false;
+
+  void setValidImage() {
+    setState(() {
+      validImage = true;
+    });
+  }
+
+  void bookAppointment(BuildContext context, String key) async {
+    print(widget.counselDay);
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    var rollNo = prefs.getString('roll_no');
+    var phoneNo = prefs.getString('phone_no');
+    //prefs.setString('counselPsychDay', counselDay);
+    //prefs.setBool('hasBooked', true);
+    prefs.setString('bookedDate', widget.date);
+    prefs.setString('bookingType', widget.type);
+    prefs.setString(
+        'bookDate',
+        ((widget.type == "psych")
+            ? DateConfig.psychDate.toString()
+            : DateConfig.counselDate.toString()));
+    print(DateConfig.bookedDate.toString());
+    prefs.setString('bookedTime', widget.time);
+
+    var reference = (widget.type == "psych")
+        ? ScpDatabase.psychRef
+        : ScpDatabase.counselRef;
+
+    setState(() {
+      uploading = true;
+    });
+
+    StorageReference ref = FirebaseStorage.instance.ref().child(widget.type + "$key.jpg");
+    StorageUploadTask uploadTask = ref.putFile(File(imagePath));
+    var futureUrl = (await uploadTask.onComplete).ref.getDownloadURL();
+
+    String imageUrl;
+
+    await futureUrl.then((url) {
+      imageUrl = url;
+    });
+
+    await reference.child(key).update({
+      "phoneNo": phoneNo,
+      "rollNo": rollNo,
+      "status": "1",
+      "idImage": imageUrl,
+    }).then((_) {
+      print("Value updated");
+      Navigator.pushAndRemoveUntil(
+          context,
+          MaterialPageRoute(
+              builder: (BuildContext context) => Booking(
+                    keyCode: key,
+                    counselDay: widget.counselDay,
+                    time: widget.time,
+                  )),
+          ModalRoute.withName('/appointments'));
+      //Navigator.push(context, MaterialPageRoute(
+      //  builder: (BuildContext context) =>
+      //    Booking(keyCode: key, counselDay: widget.counselDay, time: widget.time)));
+    });
+
+    setState(() {
+      uploading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    queryWidth = MediaQuery.of(context).size.width;
+
+    return Scaffold(
+      key: _scafoldKey,
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(
+          60.0,
+        ),
+        child: AppBar(
+          title: Padding(
+            padding: const EdgeInsets.only(
+              top: 8.0,
+            ),
+            child: Text(
+              'Book your appointment',
+              style: TextStyle(
+                  fontSize: queryWidth * 0.065,
+                  fontFamily: 'PfDin',
+                  fontWeight: FontWeight.w500),
+            ),
+          ),
+          backgroundColor: Color.fromRGBO(
+            54,
+            66,
+            87,
+            1.0,
+          ),
+          leading: Padding(
+            padding: const EdgeInsets.only(top: 8.0),
+            child: IconButton(
+              onPressed: () {
+                Navigator.of(context);
+                Navigator.pushNamed(context, '/appointments');
+              },
+              icon: Icon(
+                Icons.arrow_back_ios,
+              ),
+            ),
+          ),
+          elevation: 0.0,
+        ),
+      ),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          Text(
+            'Booking',
+            style: TextStyle(
+              color: Colors.black,
+              fontFamily: 'PfDin',
+              fontSize: MediaQuery.of(context).size.width * 0.052,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Text(
+              '${widget.counselDay} | ${widget.date} | ${widget.time}',
+              style: TextStyle(
+                  color: Colors.black,
+                  fontFamily: 'PfDin',
+                  fontSize: MediaQuery.of(context).size.width * 0.038,
+                  fontWeight: FontWeight.w500,
+              ),
+              textAlign: TextAlign.left,
+            ),
+          ),
+          Container(
+            width: double.infinity,
+            padding: EdgeInsets.all(16.0),
+            child: Center(
+              child: Wrap(
+                children: <Widget>[
+                  Text(
+                    'Upload image of ID card',
+                    style: TextStyle(
+                        color: Colors.black,
+                        fontFamily: 'PfDin',
+                        fontSize: MediaQuery.of(context).size.width * 0.052,
+                        fontWeight: FontWeight.w500),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          FlatButton(
+            padding: EdgeInsets.all(0),
+            onPressed: () async {
+              if (validImage) {
+                var file = File(imagePath);
+                file.delete();
+
+                setState(() {
+                  validImage = false;
+                });
+              }
+
+              // Construct the path where the image should be saved using the
+              // pattern package.
+              final path = join(
+                // Store the picture in the temp directory.
+                // Find the temp directory using the `path_provider` plugin.
+                (await getTemporaryDirectory()).path,
+                '${DateTime.now()}.png',
+              );
+
+              uploadImage(context, path, setValidImage);
+
+              imagePath = path;
+            },
+            splashColor: Colors.transparent,
+            child: validImage
+                ? Container(
+                    height: 120,
+                    width: 120,
+                    child: Image.file(
+                      File(imagePath),
+                      fit: BoxFit.cover,
+                    ),
+                  )
+                : Container(
+                    height: 120,
+                    width: 120,
+                    child: Icon(
+                      Icons.add,
+                      size: 40,
+                      color: Colors.grey,
+                    ),
+                    decoration: BoxDecoration(
+                      border: Border.all(color: Colors.grey),
+                    ),
+                  ),
+          ),
+          Padding(
+            padding: EdgeInsets.all(16.0),
+            child: RaisedButton(
+              color: !uploading
+                  ? Color.fromRGBO(54, 66, 87, 1.0)
+                  : Color.fromRGBO(164, 176, 197, 1.0),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8.0),
+              ),
+              onPressed: () {
+                if (!validImage) {
+                  _scafoldKey.currentState.showSnackBar(SnackBar(content: Text('First upload an image')));
+                } else if (!uploading) {
+                  bookAppointment(context, widget.bookingKey);
+                }
+              },
+              child: !uploading ? Text('Upload and Book') : Text('Uploading'),
+              textColor: Colors.white,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/scp/pubspec.yaml
+++ b/scp/pubspec.yaml
@@ -29,6 +29,9 @@ dependencies:
   cupertino_icons: ^0.1.2
   url_launcher: ^5.1.0
   intl: ^0.15.2
+  camera: ^0.5.7
+  path_provider: ^1.0.0
+  firebase_storage: ^3.0.8
 
 dev_dependencies:
   flutter_launcher_icons: "^0.7.2"


### PR DESCRIPTION
**This PR solves:**  #57 

The modifications are made so that the user can upload ID card images. Two extra screens are added, i.e. Confirmation and upload screen and the camera screen.

The image is uploaded to firebase storage with a file name format "{type}{slot}.png" and then it's URL is kept as a separate new field in firebase realtime database under key `idImage` for every slot booking.


![Screenshot_1575722290](https://user-images.githubusercontent.com/35187467/70375129-4a096900-1920-11ea-8f61-29f5a8b08f90.png)
![Screenshot_1575722399](https://user-images.githubusercontent.com/35187467/70375130-4b3a9600-1920-11ea-9368-3a8e4b866535.png)
![Screenshot_1575722407](https://user-images.githubusercontent.com/35187467/70375131-4bd32c80-1920-11ea-8e6c-d3cd34227fbb.png)